### PR TITLE
Add scoop installation reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,12 @@ Styles must still have a format-wise valid signature appended, it is just not ve
 
 [Development builds](https://github.com/namazso/SecureUxTheme/actions)
 
+[Scoop:](https://scoop.sh/)
+```shell
+scoop bucket add extras
+scoop install secureuxtheme
+```
+
 ## Download is MALWARE???
 
 Some silly antiviruses tend to flag the tool as malware, because it's unsigned (this method of detection [clearly](https://www.securityweek.com/use-fake-code-signing-certificates-malware-surges) [works](https://www.zdnet.com/article/hackers-are-selling-legitimate-code-signing-certificates-to-evade-malware-detection/) [btw](http://signedmalware.org/)). I'm submitting all releases before release to Microsoft for analysis if they're detected by Defender, but I can't guarantee the same for all the other AVs. If you have a signing certificate and are willing help signing, please contact me.


### PR DESCRIPTION
I forgot that I added SecureUxTheme to scoop a few days ago and a reference to it would be nice.