### PR TITLE
UI tweaks

### DIFF
--- a/ThemeTool/MainDialog.cpp
+++ b/ThemeTool/MainDialog.cpp
@@ -859,6 +859,9 @@ void MainDialog::PatchTheme(int id)
       _is_elevated ? ESTRt(L"Consider sending a bug report") : ESTRt(L"Try running the program as Administrator")
     );
   }
+
+  // reload theme details (patch status)
+  SelectTheme(id);
 }
 
 int MainDialog::CurrentSelection()

--- a/ThemeTool/MainDialog.cpp
+++ b/ThemeTool/MainDialog.cpp
@@ -935,10 +935,14 @@ INT_PTR MainDialog::DlgProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
   case WM_NOTIFY:
     {
     const auto nmhdr = (LPNMHDR)lParam;
-    if (nmhdr->idFrom == IDC_LIST && nmhdr->code == NM_CLICK)
+    if (nmhdr->idFrom == IDC_LIST && nmhdr->code == LVN_ITEMCHANGED)
     {
-      SelectTheme(CurrentSelection());
-      return TRUE;
+      const auto pnmv = (LPNMLISTVIEW)lParam;
+      if (pnmv->uNewState & LVIS_SELECTED)
+      {
+        SelectTheme(pnmv->iItem);
+        return TRUE;
+      }
     }
     }
     return FALSE;


### PR DESCRIPTION
- fix theme list box selection handling
  - uses `LVN_ITEMCHANGED` notification so using arrow keys to select items in the theme list box works correctly now (was previously using `NM_CLICK`)
- reload theme details after patching
  - calls `SelectTheme` at the end of `PatchTheme` to reload the patch status labels