### PR TITLE
Set MainDialog position to be centered on the screen

### DIFF
--- a/ThemeTool/main.cpp
+++ b/ThemeTool/main.cpp
@@ -111,19 +111,23 @@ int APIENTRY wWinMain(
 
   RECT rc;
   GetWindowRect(dialog, &rc);
-  
-  const auto screen_width = GetSystemMetrics(SM_CXSCREEN);
-  const auto screen_height = GetSystemMetrics(SM_CYSCREEN);
-  
+
+  const auto hwnd_monitor = MonitorFromWindow(dialog, MONITOR_DEFAULTTONEAREST);
+  MONITORINFO monitor_info{};
+  monitor_info.cbSize = sizeof(monitor_info);
+  GetMonitorInfoW(hwnd_monitor, &monitor_info);
+
+  const auto& monitor_rc = monitor_info.rcMonitor;
+
   const auto dialog_width = rc.right - rc.left;
   const auto dialog_height = rc.bottom - rc.top;
 
-  const auto x = (screen_width - dialog_width) / 2;
-  const auto y = (screen_height - dialog_height) / 2;
+  const auto x = monitor_rc.left + (monitor_rc.right - monitor_rc.left - dialog_width) / 2;
+  const auto y = monitor_rc.top + (monitor_rc.bottom - monitor_rc.top - dialog_height) / 2;
 
   SetWindowPos(dialog, nullptr, x, y, 0, 0, SWP_NOSIZE | SWP_NOZORDER); // Set window position to be both vertically and horizontally centered on the screen.
-  
   ShowWindow(dialog, cmd_show);
+
 
   MSG msg{};
   while (GetMessage(&msg, nullptr, 0, 0))

--- a/ThemeTool/main.cpp
+++ b/ThemeTool/main.cpp
@@ -108,6 +108,21 @@ int APIENTRY wWinMain(
     &DlgProcClassBinder<MainDialog>,
     0
   );
+
+  RECT rc;
+  GetWindowRect(dialog, &rc);
+  
+  const auto screen_width = GetSystemMetrics(SM_CXSCREEN);
+  const auto screen_height = GetSystemMetrics(SM_CYSCREEN);
+  
+  const auto dialog_width = rc.right - rc.left;
+  const auto dialog_height = rc.bottom - rc.top;
+
+  const auto x = (screen_width - dialog_width) / 2;
+  const auto y = (screen_height - dialog_height) / 2;
+
+  SetWindowPos(dialog, nullptr, x, y, 0, 0, SWP_NOSIZE | SWP_NOZORDER); // Set window position to be both vertically and horizontally centered on the screen.
+  
   ShowWindow(dialog, cmd_show);
 
   MSG msg{};


### PR DESCRIPTION
Shows the window (MainDialog) at the center of the screen, instead of the top left position which it uses by default.